### PR TITLE
Fix the splits issue for OrderedPartitioner ranges

### DIFF
--- a/src/main/java/com/netflix/astyanax/AstyanaxContext.java
+++ b/src/main/java/com/netflix/astyanax/AstyanaxContext.java
@@ -30,7 +30,7 @@ import com.netflix.astyanax.shallows.EmptyKeyspaceTracerFactory;
  * 
  * @author elandau
  * 
- * @param <T>
+ * @param <Entity>
  */
 public class AstyanaxContext<Entity> {
     private final ConnectionPool<?> cp;

--- a/src/main/java/com/netflix/astyanax/Keyspace.java
+++ b/src/main/java/com/netflix/astyanax/Keyspace.java
@@ -15,6 +15,7 @@
  ******************************************************************************/
 package com.netflix.astyanax;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 
@@ -177,6 +178,14 @@ public interface Keyspace {
      * @since Cassandra 1.1.8+
      */
     List<CfSplit> describeSplitsEx(String cfName, String startToken, String endToken, int keysPerSplit)
+            throws ConnectionException;
+
+    /**
+     * This is an overloaded method of {@code describeSplitsEx}, which can be used for OrderedPartitioners.
+     * This method allows for passing a rowKey for ensuring token-aware connections.
+     */
+    List<CfSplit> describeSplitsEx(String cfName, String startToken, String endToken, int keysPerSplit,
+                                   ByteBuffer rowKey)
             throws ConnectionException;
 
     /**

--- a/src/main/java/com/netflix/astyanax/test/TestKeyspace.java
+++ b/src/main/java/com/netflix/astyanax/test/TestKeyspace.java
@@ -15,6 +15,7 @@
  ******************************************************************************/
 package com.netflix.astyanax.test;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 
@@ -153,7 +154,13 @@ public class TestKeyspace implements Keyspace {
     }
 
     @Override
-    public List<CfSplit> describeSplitsEx(String cfName, String startToken, String endToken, int keysPerSplit) throws ConnectionException {
+    public List<CfSplit> describeSplitsEx(String cfName, String startToken, String endToken, int keysPerSplit)
+            throws ConnectionException {
+        return null;
+    }
+
+    @Override
+    public List<CfSplit> describeSplitsEx(String cfName, String startToken, String endToken, int keysPerSplit, ByteBuffer startKey) throws ConnectionException {
         return null;
     }
 


### PR DESCRIPTION
- Currently, many ranges do not return any splits since the token-aware connection pooling doesn't take effect.
- This introduces an overloaded method for describeSplitsEx that accepts a rowKey.
